### PR TITLE
Update 011-starting.md

### DIFF
--- a/readme/011-starting.md
+++ b/readme/011-starting.md
@@ -16,6 +16,6 @@ When starting Kismet via systemd, you should install kismet as suidroot, and use
 
 ```
 [Service]
-user=your-unprivileged-user
-group=kismet
+User=your-unprivileged-user
+Group=kismet
 ```


### PR DESCRIPTION
Minor fix on override.conf, lower case user and group causes:

systemd[1]: [/etc/systemd/system/kismet.service.d/override.conf:2] Unknown lvalue 'user' in section 'Service'
systemd[1]: [/etc/systemd/systemd/system/kismet.service.d/override.conf:3] Unknown lvalue 'group' in section 'Service'