### PR TITLE
Fixed individual tools apt install command

### DIFF
--- a/readme/006-packages.md
+++ b/readme/006-packages.md
@@ -137,7 +137,7 @@ $ sudo apt install kismet
 
 Individual tools can still be installed:
 ```bash
-$ sudo apt install kismet-core kismet-capture-linux-bluetooth kismet-capture-linux-wifi kismet-capture-nrf-mousejack python-kismetcapturertl433 python-kismetcapturertladsb python-kismetcaptureamr python-kismetcapturefreaklabszigbee kismet-logtools 
+$ sudo apt install kismet-core kismet-capture-linux-bluetooth kismet-capture-linux-wifi kismet-capture-nrf-mousejack python-kismetcapturertl433 python-kismetcapturertladsb python-kismetcapturertlamr python-kismetcapturefreaklabszigbee kismet-logtools 
 ```
 
 To install the debug version:


### PR DESCRIPTION
I ran the command when first reading the documentation and noticed one of the packages did not have the correct name. The APT repository I was using was the one listed under Kali Linux (Intel, Raspberry Pi) 

I'm running Parrot Linux, here's the uname output. If any other information is needed, please let me know.
`Linux parrot 4.19.0-parrot4-28t-amd64 #1 SMP Parrot 4.19.28-2parrot4.28t (2019-04-18) x86_64 GNU/Linux`