### PR TITLE
Documentation for TI CC2540 and CC2531 datasource

### DIFF
--- a/readme/061-datasources_ticc2540.md
+++ b/readme/061-datasources_ticc2540.md
@@ -1,0 +1,67 @@
+---
+title: "nRF Mousejack sources"
+permalink: /docs/readme/datasources_nrf_mousejack/
+excerpt: "nRF Mosuejack based datasources use a nRF USB device to detect many common wireless keyboards and mice."
+docgroup: "readme"
+toc: true
+---
+
+## Mousejack / nRF
+
+The NordicRF nRF chip is a common chip used in wireless keyboards, mice, and presentation tools, which are frequently found in non-Bluetooth wireless input devices.
+
+The Mousejack firmware developed by Bastille (https://www.mousejack.com/) runs on a number of commodity USB nRF devices (such as the Sparkfun nRF and the CrazyPA).
+
+### Datasource - nRF Mousejack
+
+Kismet must be compiled with support for libusb to use Mousejack; you will need `libusb-1.0-dev` (or the equivalent for your distribution), and you will need to make sure that the `nRF Mousejack` option is enabled in the output from `./configure`.
+
+To use the mousejack capture, you must have a supported nRF USB device; this includes any device listed on the Bastille Mousejack site, including:
+- CrazyRadio PA USB dongle
+- SparkFun nRF24LU1+ breakout board
+- Logitech Unifying dongle (model C-U0007, Nordic Semiconductor based)
+
+You will need to flash your device with the Bastille Mousejack firmware; the firmware is available at [https://github.com/BastilleResearch/mousejack](https://github.com/bastilleresearch/mousejack) by following the instructions in the [Mousejack README](https://github.com/BastilleResearch/mousejack/blob/master/readme.md).
+
+#### Mousejack interfaces
+
+Mousejack datasources in Kismet can be referred to as simply `mousejack`:
+
+```bash
+$ kismet -c mousejack
+```
+
+When using multiple Mousejack radios, they can be specified by their location in the USB bus; this can be detected automatically by Kismet as a supported interface in the web UI, or specified manually.  To find the location on the USB bus, look at the output of the command `lsusb`:
+
+```bash
+$ lsusb
+...
+Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+Bus 003 Device 008: ID 1915:0102 Nordic Semiconductor ASA 
+Bus 003 Device 010: ID 1915:0102 Nordic Semiconductor ASA 
+...
+```
+
+In this instance the first device is on `bus 003` and `device 008` and the second device is on `bus 003` and `device 010`; we can specify this specific first device in Kismet by using:
+
+```bash
+$ kismet -c mousejack-3-8
+```
+
+#### Channel Hopping
+
+The nRF protocol as used by Mousejack covers 82 channels, each 1MHz wide.
+
+To cover this spectrum rapidly, it is recommended that you increase the hop rate for nRF interfaces:
+
+```bash
+$ kismet -c mousejack-3-8:channel_hoprate=100/sec
+```
+
+This can also be specified in the `kismet.conf` or `kismet_site.conf` config files:
+
+```
+source=mousejack:name=nRF,channel_hoprate=100/sec
+```
+
+

--- a/readme/061-datasources_ticc2540.md
+++ b/readme/061-datasources_ticc2540.md
@@ -1,67 +1,49 @@
 ---
-title: "nRF Mousejack sources"
-permalink: /docs/readme/datasources_nrf_mousejack/
-excerpt: "nRF Mosuejack based datasources use a nRF USB device to detect many common wireless keyboards and mice."
+title: "TI CC2540 sources"
+permalink: /docs/readme/datasources_ticc2540/
+excerpt: "TI CC2540 based datasources use a Texas Instruments CC2540 dongle with sniffer firmware to monitor btle."
 docgroup: "readme"
 toc: true
 ---
 
-## Mousejack / nRF
+## TI CC2540
 
-The NordicRF nRF chip is a common chip used in wireless keyboards, mice, and presentation tools, which are frequently found in non-Bluetooth wireless input devices.
+The Texas Instruments CC2540 is a chip used for bluetooth communications. It can be obtained in as a usb dongle that can be flashed with a sniffer firmware provided by TI. http://www.ti.com/tool/PACKET-SNIFFER
 
-The Mousejack firmware developed by Bastille (https://www.mousejack.com/) runs on a number of commodity USB nRF devices (such as the Sparkfun nRF and the CrazyPA).
+### Datasource - TI CC2540
 
-### Datasource - nRF Mousejack
+Kismet must be compiled with support for libusb to use TICC2540; you will need `libusb-1.0-dev` (or the equivalent for your distribution), and you will need to make sure that the `TI CC 2540` option is enabled in the output from `./configure`.
 
-Kismet must be compiled with support for libusb to use Mousejack; you will need `libusb-1.0-dev` (or the equivalent for your distribution), and you will need to make sure that the `nRF Mousejack` option is enabled in the output from `./configure`.
+To use the TI CC2540 capture, you must have a TI CC2540 dongle flashed with the sniffer firmware. You can flash this yourself with a CC-Debugger or purchase one online from many retailers.
 
-To use the mousejack capture, you must have a supported nRF USB device; this includes any device listed on the Bastille Mousejack site, including:
-- CrazyRadio PA USB dongle
-- SparkFun nRF24LU1+ breakout board
-- Logitech Unifying dongle (model C-U0007, Nordic Semiconductor based)
+#### TI CC2540 interfaces
 
-You will need to flash your device with the Bastille Mousejack firmware; the firmware is available at [https://github.com/BastilleResearch/mousejack](https://github.com/bastilleresearch/mousejack) by following the instructions in the [Mousejack README](https://github.com/BastilleResearch/mousejack/blob/master/readme.md).
-
-#### Mousejack interfaces
-
-Mousejack datasources in Kismet can be referred to as simply `mousejack`:
+TI CC2540 datasources in Kismet can be referred to as simply `ticc2540`:
 
 ```bash
-$ kismet -c mousejack
+$ kismet -c ticc2540
 ```
 
-When using multiple Mousejack radios, they can be specified by their location in the USB bus; this can be detected automatically by Kismet as a supported interface in the web UI, or specified manually.  To find the location on the USB bus, look at the output of the command `lsusb`:
+When using multiple TI CC2540 dongles, they can be specified by their location in the USB bus; this can be detected automatically by Kismet as a supported interface in the web UI, or specified manually.  To find the location on the USB bus, look at the output of the command `lsusb`:
 
 ```bash
 $ lsusb
 ...
-Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
-Bus 003 Device 008: ID 1915:0102 Nordic Semiconductor ASA 
-Bus 003 Device 010: ID 1915:0102 Nordic Semiconductor ASA 
+Bus 001 Device 008: ID 0451:16b3 Texas Instruments, Inc. 
+Bus 005 Device 004: ID 0451:16b3 Texas Instruments, Inc.
+Bus 006 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub
 ...
 ```
 
-In this instance the first device is on `bus 003` and `device 008` and the second device is on `bus 003` and `device 010`; we can specify this specific first device in Kismet by using:
+In this instance the first device is on `bus 001` and `device 008` and the second device is on `bus 005` and `device 004`; we can specify this specific first device in Kismet by using:
 
 ```bash
-$ kismet -c mousejack-3-8
+$ kismet -c ticc2540-1-8
 ```
 
 #### Channel Hopping
 
-The nRF protocol as used by Mousejack covers 82 channels, each 1MHz wide.
-
-To cover this spectrum rapidly, it is recommended that you increase the hop rate for nRF interfaces:
-
-```bash
-$ kismet -c mousejack-3-8:channel_hoprate=100/sec
-```
-
-This can also be specified in the `kismet.conf` or `kismet_site.conf` config files:
-
-```
-source=mousejack:name=nRF,channel_hoprate=100/sec
+Btle has 3 advertising channels 37, 38, and 39.
 ```
 
 

--- a/readme/062-datasources_ticc2531.md
+++ b/readme/062-datasources_ticc2531.md
@@ -1,0 +1,48 @@
+---
+title: "TI CC2531 sources"
+permalink: /docs/readme/datasources_ticc2531/
+excerpt: "TI CC2531 based datasources use a Texas Instruments CC2531 dongle with sniffer firmware to monitor 802.15.4 zigbee."
+docgroup: "readme"
+toc: true
+---
+
+## TI CC2531
+
+The Texas Instruments CC2531 is a chip used for 802.15.4 zigbee communications. It can be obtained in as a usb dongle that can be flashed with a sniffer firmware provided by TI. http://www.ti.com/tool/PACKET-SNIFFER
+
+### Datasource - TI CC2531
+
+Kismet must be compiled with support for libusb to use TICC2531; you will need `libusb-1.0-dev` (or the equivalent for your distribution), and you will need to make sure that the `TI CC 2531` option is enabled in the output from `./configure`.
+
+To use the TI CC2531 capture, you must have a TI CC2531 dongle flashed with the sniffer firmware. You can flash this yourself with a CC-Debugger or purchase one online from many retailers.
+
+#### TI CC2531 interfaces
+
+TI CC2531 datasources in Kismet can be referred to as simply `ticc2531`:
+
+```bash
+$ kismet -c ticc2531
+```
+
+When using multiple TI CC2531 dongles, they can be specified by their location in the USB bus; this can be detected automatically by Kismet as a supported interface in the web UI, or specified manually.  To find the location on the USB bus, look at the output of the command `lsusb`:
+
+```bash
+$ lsusb
+...
+Bus 001 Device 008: ID 0451:16ae Texas Instruments, Inc. 
+Bus 005 Device 004: ID 0451:16ae Texas Instruments, Inc.
+Bus 006 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub
+...
+```
+
+In this instance the first device is on `bus 001` and `device 008` and the second device is on `bus 005` and `device 004`; we can specify this specific first device in Kismet by using:
+
+```bash
+$ kismet -c ticc2531-1-8
+```
+
+#### Channel Hopping
+
+Zigbee has 16 advertising channels 11-26
+```
+

--- a/readme/063-datasources_nrf51822.md
+++ b/readme/063-datasources_nrf51822.md
@@ -1,0 +1,29 @@
+---
+title: "nRF 51822 sources"
+permalink: /docs/readme/datasources_nrf_51822/
+excerpt: "nRF 51822 based datasources use a nrf51822 dongle with sniffer firmware to monitor Bluetooth LE. IE Adafruit BLE Sniffer"
+docgroup: "readme"
+toc: true
+---
+
+## nRF 51822
+
+The nRF 51822 is a chip used for Bluetooth LE communications. It can be obtained in as a usb dongle that can be flashed with a sniffer firmware provided by nRF. A pre-flashed version is available from Afafruit
+
+### Datasource - nRF 51822
+
+The nRF 51822 utilizes serial communications so no special libraries are needed for use with Kismet.
+
+#### nRF 51822 interfaces
+
+nRF 51822 datasources in Kismet can be referred to as simply `nrf51822`. Due to them being serial devices the com port used will need to be defined in the config.
+
+```bash
+source=nrf51822:device=dev/ttyUSB0
+```
+
+#### Channel Hopping
+
+The firmware does it's own channel hopping so no selections are available.
+```
+


### PR DESCRIPTION
I used the mousejack documentation as a basis for these. Fairly simple. Can include instructions on how to flash the sniffer firmware, but it is rather easy to just buy the devices pre-flashed.

Feel free to change the file name numbers (061,062)

Hopefully this helps.