### PR TITLE
Rest API commands problem with provided Content-type header

### DIFF
--- a/devel/rest/015-logins_and_sessions.md
+++ b/devel/rest/015-logins_and_sessions.md
@@ -205,7 +205,7 @@ Roles are not inherited or cascading; for instance a `readonly` role does not ha
 
 * Notes
 
-    If `httpd_allow_auth_view` is not set to `true` in the Kismet configuration, the response will not include then HTTP auth token.
+    If `httpd_allow_auth_view` is not set to `true` in the Kismet configuration, the response will not include the HTTP auth token.
 
 * Results
 

--- a/devel/rest/020-commands.md
+++ b/devel/rest/020-commands.md
@@ -13,7 +13,7 @@ This may be subject to change as the HTTP interface evolves.
 Commands should always be sent using the `x-www-form-encoded` content type; if your API does not do this by default, you may need to specify:
 
 ```javascript
-Content-Type: application/x-www-form-urlencoded; charset=utf-8
+Content-Type: application/x-www-form-urlencoded
 ```
 
 as part of the requests you send.


### PR DESCRIPTION
kismet version built from git master pulled last night
```
$ curl -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' -d 'json={"name":"advcryptchange","text":"test alert 2"}' http://kismet:PASSWORD@127.0.0.1:2501/alerts/raise_alerts.cmd
Invalid request:  Unknown alert type ''
$ curl -H 'Content-Type: application/x-www-form-urlencoded' -d 'json={"name":"advcryptchange","text":"test alert"}' http://kismet:PASSWORD@127.0.0.1:2501/alerts/raise_alerts.cmd
Alert raised
```