### PR TITLE
Removed extra whitespace from quickstart doc

### DIFF
--- a/readme/005-quickstart_compiling.md
+++ b/readme/005-quickstart_compiling.md
@@ -172,6 +172,6 @@ Kismet has many configuration knobs and options; but for the quickest way to get
 
 10.  You're now ready to run Kismet!  
     
-    Check out the [quick-start guide for running Kismet](/docs/readme/starting_kismet/) for more information!
+   Check out the [quick-start guide for running Kismet](/docs/readme/starting_kismet/) for more information!
 
 


### PR DESCRIPTION
Extra whitespace in quickstart doc was causing markdown to be rendered raw, and a link to not be linked.